### PR TITLE
addresses deprecated get_context_instance() call

### DIFF
--- a/results.php
+++ b/results.php
@@ -25,7 +25,14 @@ require_login($courseid, true); //Use course 1 because this has nothing to do wi
 
 global $CFG, $PAGE, $OUTPUT, $DB, $USER;
 
-$context = get_context_instance(CONTEXT_COURSE, $courseid);
+if(class_exists('context_course'))
+{
+    $context = context_course::instance($courseid);
+}
+else
+{
+    $context = get_context_instance(CONTEXT_COURSE, $courseid);
+}
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_url('/blocks/course_search/results.php', array('id' => $courseid));


### PR DESCRIPTION
Using the same approach as in the block_course_search.php file: test for the 'context_course' class and use it if it is available. 
