### PR TITLE
Links to sections go to the section page

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -107,7 +107,7 @@ function block_course_search_search_section($courseid, $q)
 
     foreach ($results as $result)
     {
-        $link = "<li><a href='$CFG->wwwroot/course/view.php?id=$courseid#section-$result->section'><img src='" . $OUTPUT->pix_url('icon', 'label') . "' alt='section - '/>&nbsp;$result->name</a></li>";
+        $link = "<li><a href='$CFG->wwwroot/course/view.php?id=$courseid&sectionid=$result->id'><img src='" . $OUTPUT->pix_url('icon', 'label') . "' alt='section - '/>&nbsp;$result->name</a></li>";
         $ret .= $link;
     }
     return $ret;
@@ -163,7 +163,7 @@ function block_course_search_search_module_label($courseid, $module, $q, $modinf
 
         if ($sectionfounded != null)
         {
-            $ret .= "<li><a href='$CFG->wwwroot/course/view.php?id=$courseid#section-$sectionfounded->section'><img src='" . $OUTPUT->pix_url('icon', 'label') . "' alt='label - '/>&nbsp;$result->name</a></li>";
+            $ret .= "<li><a href='$CFG->wwwroot/course/view.php?id=$courseid&sectionid=$sectionfounded->id'><img src='" . $OUTPUT->pix_url('icon', 'label') . "' alt='label - '/>&nbsp;$result->name</a></li>";
         }
     }
     return $ret;

--- a/results.php
+++ b/results.php
@@ -25,7 +25,15 @@ require_login($courseid, true); //Use course 1 because this has nothing to do wi
 
 global $CFG, $PAGE, $OUTPUT, $DB, $USER;
 
-$context = get_context_instance(CONTEXT_COURSE, $courseid);
+//Replace get_context_instance by the class for moodle 2.6+
+if(class_exists('context_module'))
+{
+    $context = context_course::instance($courseid);
+}
+else
+{
+    $context = get_context_instance(CONTEXT_COURSE, $courseid);
+}
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_url('/blocks/course_search/results.php', array('id' => $courseid));


### PR DESCRIPTION
Previously, search results with links to sections would go to the section anchor on the course page, which works fine for topic based courses. However if the course is flexible sections based and the section in question is collapsed, the link doesn't really work.
This change makes the links to a section open that section page, rather than use the anchor tag - that way the content found can be seen regardless of the course format.

The change to results.php is just to bring it up to speed with the change (that has already been applied in the download zip) for getting the section context.
